### PR TITLE
Handle unknown MeteoSwiss weather icon gracefully

### DIFF
--- a/custom_components/meteoswiss/weather.py
+++ b/custom_components/meteoswiss/weather.py
@@ -191,11 +191,11 @@ class MeteoSwissWeather(
                 str(CODE_TO_CONDITION_MAP.get(symbolId, ("", None))[0]) or None
             )
             if cond is None:
-                _LOGGER.error(
-                    "Expected a known int for the forecast icon, not None",
+                _LOGGER.warning(
+                    "Expected a known int for the forecast icon, got %s",
                     symbolId,
                 )
-                return STATE_UNAVAILABLE
+                return None
             _LOGGER.debug(
                 "Current symbol is %s, condition is: %s",
                 symbolId,


### PR DESCRIPTION
## Problem

The MeteoSwiss API can return `32767` in `currentWeather.icon`.

Example:

```json
{
  "currentWeather": {
    "time": 1782682800000,
    "icon": 32767,
    "iconV2": 101,
    "temperature": 32767.0
  }
}
```
32767 is not a known MeteoSwiss weather icon in this integration. It looks like a placeholder for a missing or invalid value.
Before this change, the weather entity became unavailable when this happened, even if other forecast data was still available.

## Fix
If currentWeather.icon is unknown, the integration now returns None for condition instead of STATE_UNAVAILABLE.
The case is also logged as a warning.

## Why
A missing or invalid icon should not make the whole weather entity unavailable.
With this fix, the weather entity can still be used and forecast data stays available. Only the current weather condition is unknown for that update.