### PR TITLE
Handle 32767 current-weather icon sentinel

### DIFF
--- a/custom_components/meteoswiss/weather.py
+++ b/custom_components/meteoswiss/weather.py
@@ -46,6 +46,8 @@ from custom_components.meteoswiss.const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+INVALID_FORECAST_VALUE = 32767
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -112,6 +114,7 @@ class MeteoSwissWeather(
         coordinator: MeteoSwissDataUpdateCoordinator,
     ):
         super().__init__(coordinator)
+        self._invalid_legacy_icon_logged = False
         self._attr_unique_id = "weather.%s" % integration_id
         self._attr_post_code = coordinator.data[CONF_POSTCODE]
         self._attr_station = coordinator.data[CONF_STATION]
@@ -185,14 +188,28 @@ class MeteoSwissWeather(
 
     @property
     def condition(self) -> str | None:
-        symbolId = self._forecastData["currentWeather"]["icon"]
+        current_weather = self._forecastData["currentWeather"]
+        symbolId = current_weather.get("icon")
+        if symbolId in (None, INVALID_FORECAST_VALUE):
+            replacement = current_weather.get("iconV2")
+            if not self._invalid_legacy_icon_logged:
+                _LOGGER.warning(
+                    "MeteoSwiss returned invalid legacy current-weather icon %r; "
+                    "using iconV2 %r",
+                    symbolId,
+                    replacement,
+                )
+                self._invalid_legacy_icon_logged = True
+            symbolId = replacement
+        else:
+            self._invalid_legacy_icon_logged = False
         try:
             cond: str | None = (
                 str(CODE_TO_CONDITION_MAP.get(symbolId, ("", None))[0]) or None
             )
             if cond is None:
                 _LOGGER.error(
-                    "Expected a known int for the forecast icon, not None",
+                    "MeteoSwiss returned no recognized current-weather icon: %r",
                     symbolId,
                 )
                 return STATE_UNAVAILABLE


### PR DESCRIPTION
Fixes #83.

## What changed

- Treat MeteoSwiss's `32767` legacy `currentWeather.icon` value as an invalid-data sentinel.
- Fall back to `currentWeather.iconV2`, which continues to contain a valid documented icon code.
- Keep the entity unavailable when neither icon field maps to a known Home Assistant condition.
- Fix the malformed logger call that produced a secondary `Bad logger message` error.
- Emit the fallback warning once per entity per invalid-data episode instead of every time Home Assistant reads the condition property.

`currentWeather.temperature == 32767.0` does not require a fallback in this integration: the weather entity's current temperature comes from the configured real-time station data (`tre200s0`), not from `plzDetail.currentWeather.temperature`.

## Validation

- `ruff check custom_components/meteoswiss/weather.py`
- `python -m py_compile custom_components/meteoswiss/weather.py`
- Installed on Home Assistant Core 2026.5.4 with MeteoSwiss 1.4.0.
- Verified three affected entities recovered from `unavailable` using `iconV2` values `1` and `26`.
- Verified `weather.get_forecasts` returned HTTP 200 with six daily forecasts.
- Verified one clear fallback warning per entity and no logger-formatting errors.
