### PR TITLE
Fixed weather data not updating in HA

### DIFF
--- a/custom_components/meteoswiss/weather.py
+++ b/custom_components/meteoswiss/weather.py
@@ -157,6 +157,7 @@ class MeteoSwissWeather(
         """Handle data update."""
         data = self.coordinator.data
         self.__set_data(data)
+        self.async_write_ha_state()
 
     @property
     def native_temperature(self) -> float | None:


### PR DESCRIPTION
Hello @Rudd-O,
Since updating the integration to the version/commit #0bb1c42, I noticed that the weather data were not updated on changes anymore (I'm running on the latest Home Assistant v2026.7.4).

For example, at 23h yesterday, the weather data "label" was still displaying "sunny", but that was not an error coming from MeteoSwiss's data. By refreshing manually the integration, the data are updated and, in my case, were updated to match MeteoSwiss's current data.

I added the line `self.async_write_ha_state(),` in the function `def _handle_coordinator_update(self)`.

I tested this change in my Home Assistant instance and I can confirm that this change fixed the issue, the weather data are now updated on change.

Hello from Switzerland !